### PR TITLE
query refactor legacy warning

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile=black
+skip=fuel_logger/migrations

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,16 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
-    hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-    -   id: black
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v2.3.0
+      hooks:
+          - id: check-yaml
+          - id: end-of-file-fixer
+          - id: trailing-whitespace
+    - repo: https://github.com/psf/black
+      rev: 22.3.0
+      hooks:
+          - id: black
+    - repo: https://github.com/pycqa/isort
+      rev: 5.12.0
+      hooks:
+          - id: isort
+            name: isort (python)

--- a/fuel_logger/__init__.py
+++ b/fuel_logger/__init__.py
@@ -1,13 +1,13 @@
-from fuel_logger.config import Config
-
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
-from flask_migrate import Migrate
-from flask_login import LoginManager
-from flask_moment import Moment
 from flask_bootstrap import Bootstrap
+from flask_login import LoginManager
 from flask_mail import Mail
 from flask_marshmallow import Marshmallow
+from flask_migrate import Migrate
+from flask_moment import Moment
+from flask_sqlalchemy import SQLAlchemy
+
+from fuel_logger.config import Config
 
 LITRE_PER_GAL = 3.785
 LITRE_PER_GAL_IMP = 4.546

--- a/fuel_logger/api/__init__.py
+++ b/fuel_logger/api/__init__.py
@@ -2,4 +2,4 @@ from flask import Blueprint
 
 bp = Blueprint("api", __name__)
 
-from fuel_logger.api import users, errors, tokens, vehicles, fuel_logs
+from fuel_logger.api import errors, fuel_logs, tokens, users, vehicles

--- a/fuel_logger/api/auth.py
+++ b/fuel_logger/api/auth.py
@@ -1,7 +1,7 @@
-from fuel_logger.models import User
-from fuel_logger.api.errors import error_response
-
 from flask_httpauth import HTTPBasicAuth, HTTPTokenAuth, MultiAuth
+
+from fuel_logger.api.errors import error_response
+from fuel_logger.models import User
 
 basic_auth = HTTPBasicAuth()
 token_auth = HTTPTokenAuth()

--- a/fuel_logger/api/fuel_logs.py
+++ b/fuel_logger/api/fuel_logs.py
@@ -1,10 +1,11 @@
+from flask import jsonify
 from flask.globals import request
+
+from fuel_logger import db
 from fuel_logger.api import bp
 from fuel_logger.api.auth import multi_auth
-from fuel_logger.schemas.fillup import fillups_schema
 from fuel_logger.models import Fillup
-from flask import jsonify
-from fuel_logger import db
+from fuel_logger.schemas.fillup import fillups_schema
 
 
 @bp.route("/logs")

--- a/fuel_logger/api/fuel_logs.py
+++ b/fuel_logger/api/fuel_logs.py
@@ -1,12 +1,10 @@
-import re
 from flask.globals import request
-from fuel_logger.models import fillups, vehicles
 from fuel_logger.api import bp
 from fuel_logger.api.auth import multi_auth
-from fuel_logger.schemas.fillup import fillup_schema, fillups_schema
+from fuel_logger.schemas.fillup import fillups_schema
 from fuel_logger.models import Fillup
-
 from flask import jsonify
+from fuel_logger import db
 
 
 @bp.route("/logs")
@@ -16,6 +14,11 @@ def fuel_logs():
         vehicle_ids = [int(request.args.get("vehicle_id"))]
     else:
         vehicle_ids = [v.id for v in multi_auth.current_user().vehicles]
-    fillups = Fillup.query.filter(Fillup.vehicle_id.in_(vehicle_ids)).all()
+
+    fillups = (
+        db.session.execute(db.select(Fillup).filter(Fillup.vehicle_id.in_(vehicle_ids)))
+        .scalars()
+        .all()
+    )
 
     return jsonify(fillups_schema.dump(fillups))

--- a/fuel_logger/api/tokens.py
+++ b/fuel_logger/api/tokens.py
@@ -1,4 +1,5 @@
 from flask.json import jsonify
+
 from fuel_logger import db
 from fuel_logger.api import bp
 from fuel_logger.api.auth import basic_auth, multi_auth

--- a/fuel_logger/api/tokens.py
+++ b/fuel_logger/api/tokens.py
@@ -1,6 +1,5 @@
 from flask.json import jsonify
 from fuel_logger import db
-from fuel_logger.models import User
 from fuel_logger.api import bp
 from fuel_logger.api.auth import basic_auth, multi_auth
 

--- a/fuel_logger/api/users.py
+++ b/fuel_logger/api/users.py
@@ -2,6 +2,7 @@ from fuel_logger.api import bp
 from fuel_logger.api.auth import multi_auth
 from fuel_logger.models import User
 from fuel_logger.schemas.user import user_schema, users_schema
+from fuel_logger import db
 
 from flask import jsonify
 
@@ -9,7 +10,7 @@ from flask import jsonify
 @bp.route("/users/<int:id>", methods=["GET"])
 @multi_auth.login_required
 def get_user(id):
-    user = User.query.get_or_404(id)
+    user = db.get_or_404(User, id)
     return user_schema.dump(user)
 
 

--- a/fuel_logger/api/users.py
+++ b/fuel_logger/api/users.py
@@ -1,10 +1,10 @@
+from flask import jsonify
+
+from fuel_logger import db
 from fuel_logger.api import bp
 from fuel_logger.api.auth import multi_auth
 from fuel_logger.models import User
 from fuel_logger.schemas.user import user_schema, users_schema
-from fuel_logger import db
-
-from flask import jsonify
 
 
 @bp.route("/users/<int:id>", methods=["GET"])

--- a/fuel_logger/api/vehicles.py
+++ b/fuel_logger/api/vehicles.py
@@ -19,7 +19,7 @@ def vehicles():
 @bp.route("/vehicles/<int:id>")
 @multi_auth.login_required
 def vehicle_by_id(id):
-    vehicle = Vehicle.query.get_or_404(id)
+    vehicle = db.get_or_404(Vehicle, id)
     return vehicle_schema.dump(vehicle)
 
 
@@ -39,7 +39,7 @@ def create_vehicle():
 @bp.route("/vehicles/<int:id>", methods=["DELETE"])
 @multi_auth.login_required
 def delete_vehicle(id):
-    vehicle = Vehicle.query.get_or_404(id)
+    vehicle = db.get_or_404(Vehicle, id)
     db.session.delete(vehicle)
     db.session.commit()
     return jsonify({"status": "DELETED"})

--- a/fuel_logger/api/vehicles.py
+++ b/fuel_logger/api/vehicles.py
@@ -1,11 +1,11 @@
+from flask import jsonify, request
+
 from fuel_logger import db
 from fuel_logger.api import bp
-from fuel_logger.api.errors import bad_request
 from fuel_logger.api.auth import multi_auth
+from fuel_logger.api.errors import bad_request
 from fuel_logger.models import Vehicle
 from fuel_logger.schemas.vehicle import vehicle_schema, vehicles_schema
-
-from flask import jsonify, request
 
 
 @bp.route("/vehicles")

--- a/fuel_logger/auth/forms.py
+++ b/fuel_logger/auth/forms.py
@@ -1,8 +1,8 @@
-from fuel_logger.models import User
-
 from flask_wtf import FlaskForm
-from wtforms import PasswordField, BooleanField, StringField, SubmitField
+from wtforms import BooleanField, PasswordField, StringField, SubmitField
 from wtforms.validators import DataRequired, Email, EqualTo, ValidationError
+
+from fuel_logger.models import User
 
 
 class LoginForm(FlaskForm):

--- a/fuel_logger/auth/routes.py
+++ b/fuel_logger/auth/routes.py
@@ -1,17 +1,17 @@
+from flask import flash, redirect, render_template, request, url_for
+from flask_login import current_user, login_required, login_user, logout_user
+from werkzeug.urls import url_parse
+
 from fuel_logger import db
 from fuel_logger.auth import bp
 from fuel_logger.auth.forms import (
     LoginForm,
     RegistrationForm,
-    ResetPasswordRequestForm,
     ResetPasswordForm,
+    ResetPasswordRequestForm,
 )
 from fuel_logger.models import User
 from fuel_logger.utils.email import send_password_reset_email
-
-from flask import redirect, url_for, flash, request, render_template
-from flask_login import login_required, current_user, login_user, logout_user
-from werkzeug.urls import url_parse
 
 
 @bp.route("/login", methods=["GET", "POST"])

--- a/fuel_logger/config.py
+++ b/fuel_logger/config.py
@@ -1,4 +1,5 @@
 import os
+
 from dotenv import load_dotenv
 
 basedir = os.path.abspath(os.path.dirname(__file__))

--- a/fuel_logger/errors/handlers.py
+++ b/fuel_logger/errors/handlers.py
@@ -1,8 +1,9 @@
-from flask.globals import request
-from fuel_logger import db
-from fuel_logger.errors import bp
-from fuel_logger.api.errors import error_response as api_error_response
 from flask import render_template
+from flask.globals import request
+
+from fuel_logger import db
+from fuel_logger.api.errors import error_response as api_error_response
+from fuel_logger.errors import bp
 
 
 def wants_json_response():

--- a/fuel_logger/fuel_logger.py
+++ b/fuel_logger/fuel_logger.py
@@ -1,5 +1,5 @@
 from fuel_logger import create_app, db
-from fuel_logger.models import User, Vehicle, Fillup
+from fuel_logger.models import Fillup, User, Vehicle
 
 app = create_app()
 

--- a/fuel_logger/fuel_logs/forms.py
+++ b/fuel_logger/fuel_logs/forms.py
@@ -1,20 +1,21 @@
-from fuel_logger import db, KM_PER_MILE
-from fuel_logger.models import Fillup
-
 from datetime import datetime
+
 from flask import g
 from flask_wtf import FlaskForm
 from sqlalchemy import func
 from wtforms import (
     DateField,
-    TimeField,
     DecimalField,
+    FileField,
     IntegerField,
     SubmitField,
-    FileField,
+    TimeField,
     ValidationError,
 )
 from wtforms.validators import DataRequired
+
+from fuel_logger import KM_PER_MILE, db
+from fuel_logger.models import Fillup
 
 
 class FillupForm(FlaskForm):

--- a/fuel_logger/fuel_logs/forms.py
+++ b/fuel_logger/fuel_logs/forms.py
@@ -28,7 +28,7 @@ class FillupForm(FlaskForm):
 
     def validate_odometer(self, odometer):
         last_odo = (
-            db.session.query(func.max(Fillup.odometer_km))
+            db.session.query(db.func.max(Fillup.odometer_km))
             .filter_by(vehicle_id=g.vehicle.id)
             .scalar()
             or 0

--- a/fuel_logger/fuel_logs/routes.py
+++ b/fuel_logger/fuel_logs/routes.py
@@ -1,22 +1,21 @@
-from fuel_logger import db, KM_PER_MILE
-from fuel_logger.fuel_logs import bp
-from fuel_logger.fuel_logs.forms import FillupForm, ImportForm
-from fuel_logger.models import Vehicle, Fillup
+import pandas as pd
+from flask import (
+    Response,
+    current_app,
+    flash,
+    g,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from flask_login import current_user, login_required
 from werkzeug.exceptions import Forbidden
 
-from flask import (
-    render_template,
-    flash,
-    redirect,
-    url_for,
-    g,
-    request,
-    current_app,
-    Response,
-)
-from flask_login import login_required, current_user
-
-import pandas as pd
+from fuel_logger import KM_PER_MILE, db
+from fuel_logger.fuel_logs import bp
+from fuel_logger.fuel_logs.forms import FillupForm, ImportForm
+from fuel_logger.models import Fillup, Vehicle
 
 
 @bp.route("/logs/<vehicle_id>", methods=["GET", "POST"])

--- a/fuel_logger/fuel_logs/routes.py
+++ b/fuel_logger/fuel_logs/routes.py
@@ -22,7 +22,7 @@ import pandas as pd
 @bp.route("/logs/<vehicle_id>", methods=["GET", "POST"])
 @login_required
 def logs(vehicle_id):
-    v = Vehicle.query.get_or_404(vehicle_id)
+    v = db.get_or_404(Vehicle, vehicle_id)
     if v.owner != current_user:
         raise Forbidden("You have no access to these logs")
     g.vehicle = v
@@ -70,7 +70,7 @@ def logs(vehicle_id):
 @bp.route("/logs/<vehicle_id>/bulk_upload", methods=["GET", "POST"])
 @login_required
 def bulk_upload(vehicle_id):
-    vehicle = Vehicle.query.get_or_404(vehicle_id)
+    vehicle = db.get_or_404(Vehicle, vehicle_id)
     form = ImportForm()
     if request.method == "POST":
         if "file_obj" not in request.files:
@@ -100,7 +100,7 @@ def bulk_upload(vehicle_id):
 @bp.route("/logs/<vehicle_id>/bulk_download")
 @login_required
 def bulk_download(vehicle_id):
-    v = Vehicle.query.get_or_404(vehicle_id)
+    v = db.get_or_404(Vehicle, vehicle_id)
     if v.owner != current_user:
         raise Forbidden("You have no access to these logs")
     df = v.get_stats_df()
@@ -130,7 +130,7 @@ def bulk_download(vehicle_id):
 @bp.route("/logs/<vehicle_id>/bulk_delete", methods=["DELETE"])
 @login_required
 def bulk_delete(vehicle_id):
-    vehicle = Vehicle.query.get_or_404(vehicle_id)
+    vehicle = db.get_or_404(Vehicle, vehicle_id)
     if vehicle.owner != current_user:
         raise Forbidden("You have no access to these logs")
     for f in vehicle.fillups:
@@ -148,7 +148,7 @@ def bulk_delete(vehicle_id):
 @bp.route("/logs/delete/<log_id>", methods=["DELETE"])
 @login_required
 def delete_log(log_id):
-    l = Fillup.query.get_or_404(log_id)
+    l = db.get_or_404(Fillup, log_id)
     if l.vehicle.owner != current_user:
         raise Forbidden("You have no access to these logs")
     try:

--- a/fuel_logger/main/routes.py
+++ b/fuel_logger/main/routes.py
@@ -1,7 +1,7 @@
-from fuel_logger.main import bp
-
 from flask import render_template
 from flask_login import login_required
+
+from fuel_logger.main import bp
 
 
 @bp.route("/")

--- a/fuel_logger/models/__init__.py
+++ b/fuel_logger/models/__init__.py
@@ -1,3 +1,3 @@
 from .fillups import Fillup
-from .vehicles import Vehicle
 from .users import User
+from .vehicles import Vehicle

--- a/fuel_logger/models/fillups.py
+++ b/fuel_logger/models/fillups.py
@@ -1,6 +1,6 @@
-from fuel_logger import db, KM_PER_MILE, MPG_IMP_PER_MPG, MPG_LP100K
-
 from datetime import datetime
+
+from fuel_logger import KM_PER_MILE, MPG_IMP_PER_MPG, MPG_LP100K, db
 
 
 class Fillup(db.Model):

--- a/fuel_logger/models/users.py
+++ b/fuel_logger/models/users.py
@@ -1,14 +1,14 @@
-from fuel_logger import db, login
-
-from flask import current_app
-from flask_login import UserMixin
-from time import time
-from datetime import datetime, timedelta
-from werkzeug.security import generate_password_hash, check_password_hash
-
-import jwt
 import base64
 import os
+from datetime import datetime, timedelta
+from time import time
+
+import jwt
+from flask import current_app
+from flask_login import UserMixin
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from fuel_logger import db, login
 
 
 class User(UserMixin, db.Model):

--- a/fuel_logger/models/users.py
+++ b/fuel_logger/models/users.py
@@ -5,7 +5,6 @@ from flask_login import UserMixin
 from time import time
 from datetime import datetime, timedelta
 from werkzeug.security import generate_password_hash, check_password_hash
-from sqlalchemy import select
 
 import jwt
 import base64

--- a/fuel_logger/models/users.py
+++ b/fuel_logger/models/users.py
@@ -5,6 +5,7 @@ from flask_login import UserMixin
 from time import time
 from datetime import datetime, timedelta
 from werkzeug.security import generate_password_hash, check_password_hash
+from sqlalchemy import select
 
 import jwt
 import base64
@@ -38,7 +39,7 @@ class User(UserMixin, db.Model):
             )["reset_password"]
         except:
             return
-        return User.query.get(id)
+        return db.session.get(User, id)
 
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)
@@ -91,4 +92,4 @@ class User(UserMixin, db.Model):
 
 @login.user_loader
 def load_user(id):
-    return User.query.get(int(id))
+    return db.session.get(User, int(id))

--- a/fuel_logger/models/vehicles.py
+++ b/fuel_logger/models/vehicles.py
@@ -1,13 +1,13 @@
 import datetime
-from fuel_logger import db, KM_PER_MILE, MPG_IMP_PER_MPG, MPG_LP100K
-from fuel_logger.models.users import User
-from fuel_logger.models.fillups import Fillup
-from fuel_logger.utils.stats import compute_stats_from_fillup_df
-
 from datetime import datetime, timedelta
-from sqlalchemy import and_
 
 import pandas as pd
+from sqlalchemy import and_
+
+from fuel_logger import KM_PER_MILE, MPG_IMP_PER_MPG, MPG_LP100K, db
+from fuel_logger.models.fillups import Fillup
+from fuel_logger.models.users import User
+from fuel_logger.utils.stats import compute_stats_from_fillup_df
 
 
 class Vehicle(db.Model):

--- a/fuel_logger/schemas/fillup.py
+++ b/fuel_logger/schemas/fillup.py
@@ -1,8 +1,7 @@
-from fuel_logger import ma
-from fuel_logger.models import Fillup, Vehicle
-from fuel_logger import db
-
 from marshmallow import fields
+
+from fuel_logger import db, ma
+from fuel_logger.models import Fillup, Vehicle
 
 
 class FillupSchema(ma.SQLAlchemyAutoSchema):

--- a/fuel_logger/schemas/fillup.py
+++ b/fuel_logger/schemas/fillup.py
@@ -1,5 +1,6 @@
 from fuel_logger import ma
 from fuel_logger.models import Fillup, Vehicle
+from fuel_logger import db
 
 from marshmallow import fields
 
@@ -13,12 +14,17 @@ class FillupSchema(ma.SQLAlchemyAutoSchema):
     vehicle_id = fields.Method("get_vehicle_id")
 
     def get_vehicle_id(self, obj):
-        vehicle = Vehicle.query.get(obj.vehicle_id)
-        return vehicle.id
+        print(obj)
+        vehicle = db.session.get(Vehicle, obj.vehicle_id)
+        return vehicle.id if vehicle is not None else None
 
     def get_vehicle_description(self, obj):
-        vehicle = Vehicle.query.get(obj.vehicle_id)
-        return f"{vehicle.year} {vehicle.make} {vehicle.model}"
+        vehicle = db.session.get(Vehicle, obj.vehicle_id)
+        return (
+            f"{vehicle.year} {vehicle.make} {vehicle.model}"
+            if vehicle is not None
+            else None
+        )
 
 
 fillup_schema = FillupSchema()

--- a/fuel_logger/schemas/vehicle.py
+++ b/fuel_logger/schemas/vehicle.py
@@ -1,7 +1,7 @@
+from marshmallow import fields
+
 from fuel_logger import ma
 from fuel_logger.models import Vehicle
-
-from marshmallow import fields
 
 
 class VehicleSchema(ma.SQLAlchemySchema):

--- a/fuel_logger/utils/email.py
+++ b/fuel_logger/utils/email.py
@@ -1,9 +1,9 @@
-from fuel_logger import mail
-
-from flask import current_app
-from flask_mail import Message
-from flask import render_template
 from threading import Thread
+
+from flask import current_app, render_template
+from flask_mail import Message
+
+from fuel_logger import mail
 
 
 def send_email(subject, sender, recipients, text_body, html_body):

--- a/fuel_logger/vehicles/forms.py
+++ b/fuel_logger/vehicles/forms.py
@@ -1,11 +1,7 @@
 from flask_wtf import FlaskForm
-from wtforms import (
-    StringField,
-    SubmitField,
-    SelectField,
-)
-from wtforms.validators import DataRequired
+from wtforms import SelectField, StringField, SubmitField
 from wtforms.fields import IntegerField
+from wtforms.validators import DataRequired
 
 
 class VehicleForm(FlaskForm):

--- a/fuel_logger/vehicles/routes.py
+++ b/fuel_logger/vehicles/routes.py
@@ -28,7 +28,7 @@ def add_vehicle():
 @bp.route("/garage/<user_id>")
 @login_required
 def garage(user_id):
-    u = User.query.get(user_id)
+    u = db.session.get(User, user_id)
     if u != current_user:
         return (
             render_template(
@@ -44,7 +44,7 @@ def garage(user_id):
 @bp.route("/set_fav_vehicle/<user_id>/<vehicle_id>")
 @login_required
 def set_fav_vehicle(user_id, vehicle_id):
-    user = User.query.get(user_id)
+    user = db.session.get(User, user_id)
 
     if user is None:
         flash("invalid user")

--- a/fuel_logger/vehicles/routes.py
+++ b/fuel_logger/vehicles/routes.py
@@ -1,10 +1,10 @@
+from flask import flash, redirect, render_template, url_for
+from flask_login import current_user, login_required
+
 from fuel_logger import db
-from fuel_logger.models import Vehicle, User
+from fuel_logger.models import User, Vehicle
 from fuel_logger.vehicles import bp
 from fuel_logger.vehicles.forms import VehicleForm
-
-from flask import flash, render_template, redirect, url_for
-from flask_login import login_required, current_user
 
 
 @bp.route("/add_vehicle", methods=["GET", "POST"])

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
 filterwarnings =
     ignore:.*is deprecated and will be removed in.*:DeprecationWarning
-    ignore:.*method is considered legacy as of the.*:sqlalchemy.exc.LegacyAPIWarning
     ignore:.*Please set confirm_deleted_rows=False within the mapper configuration to prevent this warning..*:sqlalchemy.exc.SAWarning

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -1,4 +1,5 @@
 black==23.3.0
+isort==5.12.0
 pytest-cov==4.1.0
 pytest-mock==3.10.0
 pytest==7.3.1

--- a/tests/integration/api/test_api_logs.py
+++ b/tests/integration/api/test_api_logs.py
@@ -6,7 +6,7 @@ from fuel_logger.models import Vehicle, Fillup
 @pytest.fixture
 def sample_fillup_ids(app_fixture, test_vehicle_id):
     with app_fixture.app_context():
-        vehicle = Vehicle.query.get(test_vehicle_id)
+        vehicle = db.session.get(Vehicle, test_vehicle_id)
         # confirm initially empty
         assert vehicle.fillups.count() == 0
 
@@ -33,10 +33,15 @@ def sample_fillup_ids(app_fixture, test_vehicle_id):
 
     # Delete fillups
     with app_fixture.app_context():
-        Fillup.query.where(Fillup.id.in_(fillup_ids)).delete()
+        db.session.execute(db.delete(Fillup).where(Fillup.id.in_(fillup_ids)))
         db.session.commit()
         # Confirm deletion was successful
-        assert Fillup.query.where(Fillup.id.in_(fillup_ids)).count() == 0
+        assert (
+            db.session.scalar(
+                db.select(db.func.count(Fillup.id)).where(Fillup.id.in_(fillup_ids))
+            )
+            == 0
+        )
 
 
 def test_get_logs__no_vehicle_id(test_client, basic_auth_header):

--- a/tests/integration/api/test_api_tokens.py
+++ b/tests/integration/api/test_api_tokens.py
@@ -1,11 +1,12 @@
 import pytest
 from fuel_logger.models import User
+from fuel_logger import db
 
 
 @pytest.fixture
 def test_token(app_fixture, test_user_id):
     with app_fixture.app_context():
-        user = User.query.get(test_user_id)
+        user = db.session.get(User, test_user_id)
         assert user is not None
 
         token = user.get_api_token()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,7 +53,7 @@ def test_user_id(
     test_vehicle_id, app_fixture, test_username, test_password, test_user_email
 ):
     with app_fixture.app_context():
-        test_vehicle = Vehicle.query.get(test_vehicle_id)
+        test_vehicle = db.session.get(Vehicle, test_vehicle_id)
         user = User(
             username=test_username,
             email=test_user_email,

--- a/tests/integration/routes/test_routes_auth.py
+++ b/tests/integration/routes/test_routes_auth.py
@@ -1,6 +1,5 @@
 from fuel_logger.models import User
 from fuel_logger import db
-from sqlalchemy import select
 
 
 def test_login_get__unauthenticated(app_fixture, test_client):
@@ -136,7 +135,7 @@ def test_register__new_user(app_fixture, test_client):
     with app_fixture.app_context():
         assert (
             db.session.execute(
-                select(User).filter_by(username="newusername")
+                db.select(User).filter_by(username="newusername")
             ).one_or_none()
             is None
         )

--- a/tests/integration/routes/test_routes_auth.py
+++ b/tests/integration/routes/test_routes_auth.py
@@ -1,6 +1,6 @@
 from fuel_logger.models import User
 from fuel_logger import db
-from flask_login import logout_user
+from sqlalchemy import select
 
 
 def test_login_get__unauthenticated(app_fixture, test_client):
@@ -12,7 +12,7 @@ def test_login_get__unauthenticated(app_fixture, test_client):
 
 def test_login_get__authenticated(app_fixture, test_user_id):
     with app_fixture.app_context():
-        user = User.query.get(test_user_id)
+        user = db.session.get(User, test_user_id)
         with app_fixture.test_client(user=user) as test_client_authenticated:
             resp = test_client_authenticated.get("/auth/login", follow_redirects=True)
             assert resp.status_code == 200
@@ -24,7 +24,7 @@ def test_login_post__correct_password(
     app_fixture, test_client, test_user_id, test_password, test_username
 ):
     with app_fixture.app_context():
-        user = User.query.get(test_user_id)
+        user = db.session.get(User, test_user_id)
         assert user.username == test_username
         assert user.check_password(test_password)
         resp = test_client.post(
@@ -59,7 +59,7 @@ def test_login__wrong_password(
     wrong_password = test_password + "s"
 
     with app_fixture.app_context():
-        user = User.query.get(test_user_id)
+        user = db.session.get(User, test_user_id)
         assert user.username == test_username
         assert not user.check_password(wrong_password)
         resp = test_client.post(
@@ -78,7 +78,7 @@ def test_login__wrong_password(
 
 def test_login_post__authenticated(app_fixture, test_user_id):
     with app_fixture.app_context():
-        user = User.query.get(test_user_id)
+        user = db.session.get(User, test_user_id)
         with app_fixture.test_client(user=user) as test_client_authenticated:
             resp = test_client_authenticated.post("/auth/login", follow_redirects=True)
             assert resp.status_code == 200
@@ -88,7 +88,7 @@ def test_login_post__authenticated(app_fixture, test_user_id):
 
 def test_logout(app_fixture, test_user_id):
     with app_fixture.app_context():
-        user = User.query.get(test_user_id)
+        user = db.session.get(User, test_user_id)
 
         with app_fixture.test_client(user=user) as test_client_authenticated:
             # Confirm signed in
@@ -115,7 +115,7 @@ def test_logout(app_fixture, test_user_id):
 
 def test_register__authenticated(app_fixture, test_user_id):
     with app_fixture.app_context():
-        user = User.query.get(test_user_id)
+        user = db.session.get(User, test_user_id)
         with app_fixture.test_client(user=user) as test_client_authenticated:
             # Confirm signed in
             resp = test_client_authenticated.get(
@@ -134,7 +134,12 @@ def test_register__get(app_fixture, test_client):
 
 def test_register__new_user(app_fixture, test_client):
     with app_fixture.app_context():
-        assert User.query.filter_by(username="newusername").one_or_none() is None
+        assert (
+            db.session.execute(
+                select(User).filter_by(username="newusername")
+            ).one_or_none()
+            is None
+        )
         resp = test_client.post(
             "/auth/register",
             follow_redirects=True,
@@ -177,7 +182,7 @@ def test_register__existing_user(
 
 def test_password_reset_request__authenticated(app_fixture, test_user_id):
     with app_fixture.app_context():
-        user = User.query.get(test_user_id)
+        user = db.session.get(User, test_user_id)
         with app_fixture.test_client(user=user) as test_client_authenticated:
             resp = test_client_authenticated.get(
                 "/auth/reset_password_request", follow_redirects=True
@@ -218,7 +223,7 @@ def test_password_reset_request__post(
 
 def test_reset_password__authenticated(app_fixture, test_user_id):
     with app_fixture.app_context():
-        user = User.query.get(test_user_id)
+        user = db.session.get(User, test_user_id)
         with app_fixture.test_client(user=user) as test_client_authenticated:
             resp = test_client_authenticated.get(
                 "/auth/reset_password/abcd", follow_redirects=True
@@ -242,7 +247,7 @@ def test_reset_password__post_invalid_token(
     app_fixture, test_client, test_user_id, test_password
 ):
     with app_fixture.app_context():
-        user = User.query.get(test_user_id)
+        user = db.session.get(User, test_user_id)
         resp = test_client.post(
             "/auth/reset_password/abcd",
             follow_redirects=True,
@@ -264,7 +269,7 @@ def test_reset_password__post_mismatch_password(
     app_fixture, test_client, test_user_id, test_password
 ):
     with app_fixture.app_context():
-        user = User.query.get(test_user_id)
+        user = db.session.get(User, test_user_id)
         token = user.get_reset_password_token()
         resp = test_client.post(
             f"/auth/reset_password/{token}",
@@ -286,7 +291,7 @@ def test_reset_password__post_valid(
     app_fixture, test_client, test_user_id, test_password
 ):
     with app_fixture.app_context():
-        user = User.query.get(test_user_id)
+        user = db.session.get(User, test_user_id)
         token = user.get_reset_password_token()
         resp = test_client.post(
             f"/auth/reset_password/{token}",

--- a/tests/integration/routes/test_routes_index.py
+++ b/tests/integration/routes/test_routes_index.py
@@ -1,4 +1,5 @@
 from fuel_logger.models import User
+from fuel_logger import db
 
 
 def test_index__unauthenticated(test_client):
@@ -11,7 +12,7 @@ def test_index__unauthenticated(test_client):
 
 def test_index__authenticated(app_fixture, test_user_id):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
+        test_user = db.session.get(User, test_user_id)
 
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
             resp = test_client_authenticated.get("/index", follow_redirects=True)

--- a/tests/integration/routes/test_routes_logs.py
+++ b/tests/integration/routes/test_routes_logs.py
@@ -1,7 +1,7 @@
 from fuel_logger.models import User, Vehicle, Fillup
 from fuel_logger import db
 import pytest
-from datetime import datetime, date, time
+from datetime import datetime
 import pandas as pd
 import io
 
@@ -10,8 +10,8 @@ def test_logs__get(
     app_fixture, test_user_id, test_username, test_vehicle_id, sample_fillup_ids
 ):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
-        test_vehicle = Vehicle.query.get(test_vehicle_id)
+        test_user = db.session.get(User, test_user_id)
+        test_vehicle = db.session.get(Vehicle, test_vehicle_id)
 
         assert test_vehicle.fillups.count() == 2
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
@@ -66,7 +66,7 @@ def temp_fillup_id(app_fixture, temp_vehicle_id):
 
 def test_logs__other_user_error(app_fixture, test_user_id, temp_vehicle_id):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
+        test_user = db.session.get(User, test_user_id)
 
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
             resp = test_client_authenticated.get(
@@ -81,7 +81,7 @@ def test_logs__other_user_error(app_fixture, test_user_id, temp_vehicle_id):
 
 def test_logs__other_user_error__json(app_fixture, test_user_id, temp_vehicle_id):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
+        test_user = db.session.get(User, test_user_id)
 
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
             resp = test_client_authenticated.get(
@@ -97,8 +97,8 @@ def test_logs__other_user_error__json(app_fixture, test_user_id, temp_vehicle_id
 
 def test_logs__post(app_fixture, test_user_id, test_vehicle_id):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
-        test_vehicle = Vehicle.query.get(test_vehicle_id)
+        test_user = db.session.get(User, test_user_id)
+        test_vehicle = db.session.get(Vehicle, test_vehicle_id)
 
         assert test_vehicle.fillups.count() == 0
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
@@ -127,8 +127,8 @@ def test_logs__post_invalid(
     app_fixture, test_user_id, test_vehicle_id, sample_fillup_id_1
 ):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
-        test_vehicle = Vehicle.query.get(test_vehicle_id)
+        test_user = db.session.get(User, test_user_id)
+        test_vehicle = db.session.get(Vehicle, test_vehicle_id)
 
         assert test_vehicle.fillups.count() == 1
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
@@ -153,8 +153,8 @@ def test_logs__delete(
     app_fixture, test_vehicle_id, test_user_id, sample_fillup_id_1, sample_fillup_ids
 ):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
-        sample_vehicle = Vehicle.query.get(test_vehicle_id)
+        test_user = db.session.get(User, test_user_id)
+        sample_vehicle = db.session.get(Vehicle, test_vehicle_id)
 
         assert sample_vehicle.fillups.count() == 2
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
@@ -180,8 +180,8 @@ def test_logs__delete_error(
     )
     mocker.patch("fuel_logger.fuel_logs.routes.db.session.commit", mocked_fn)
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
-        sample_vehicle = Vehicle.query.get(test_vehicle_id)
+        test_user = db.session.get(User, test_user_id)
+        sample_vehicle = db.session.get(Vehicle, test_vehicle_id)
 
         assert sample_vehicle.fillups.count() == 2
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
@@ -211,8 +211,8 @@ def test_logs__bulk_delete(
     app_fixture, test_vehicle_id, test_user_id, sample_fillup_id_1, sample_fillup_ids
 ):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
-        sample_vehicle = Vehicle.query.get(test_vehicle_id)
+        test_user = db.session.get(User, test_user_id)
+        sample_vehicle = db.session.get(Vehicle, test_vehicle_id)
 
         assert sample_vehicle.fillups.count() == 2
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
@@ -239,8 +239,8 @@ def test_logs__bulk_delete_error(
     mocker.patch("fuel_logger.fuel_logs.routes.db.session.commit", mocked_fn)
 
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
-        sample_vehicle = Vehicle.query.get(test_vehicle_id)
+        test_user = db.session.get(User, test_user_id)
+        sample_vehicle = db.session.get(Vehicle, test_vehicle_id)
 
         assert sample_vehicle.fillups.count() == 2
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
@@ -266,8 +266,8 @@ def test_logs_bulk_upload__get(
     test_user_id,
 ):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
-        sample_vehicle = Vehicle.query.get(test_vehicle_id)
+        test_user = db.session.get(User, test_user_id)
+        sample_vehicle = db.session.get(Vehicle, test_vehicle_id)
 
         assert sample_vehicle.fillups.count() == 0
 
@@ -282,11 +282,11 @@ def test_logs_bulk_upload__post(
     app_fixture, test_vehicle_id, test_user_id, test_username, fillups_csv
 ):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
-        sample_vehicle = Vehicle.query.get(test_vehicle_id)
+        test_user = db.session.get(User, test_user_id)
+        sample_vehicle = db.session.get(Vehicle, test_vehicle_id)
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
-            test_user = User.query.get(test_user_id)
-            sample_vehicle = Vehicle.query.get(test_vehicle_id)
+            test_user = db.session.get(User, test_user_id)
+            sample_vehicle = db.session.get(Vehicle, test_vehicle_id)
             assert sample_vehicle.fillups.count() == 0
             resp = test_client_authenticated.post(
                 f"/logs/{test_vehicle_id}/bulk_upload",
@@ -307,11 +307,11 @@ def test_logs_bulk_upload__post_error(
     app_fixture, test_vehicle_id, test_user_id, invalid_csv, fillups_csv, mocker
 ):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
-        sample_vehicle = Vehicle.query.get(test_vehicle_id)
+        test_user = db.session.get(User, test_user_id)
+        sample_vehicle = db.session.get(Vehicle, test_vehicle_id)
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
-            test_user = User.query.get(test_user_id)
-            sample_vehicle = Vehicle.query.get(test_vehicle_id)
+            test_user = db.session.get(User, test_user_id)
+            sample_vehicle = db.session.get(Vehicle, test_vehicle_id)
             assert sample_vehicle.fillups.count() == 0
 
             # No data
@@ -357,8 +357,8 @@ def test_logs_bulk_download(
     app_fixture, test_user_id, test_vehicle_id, sample_fillup_ids, temp_vehicle_id
 ):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
-        test_vehicle = Vehicle.query.get(test_vehicle_id)
+        test_user = db.session.get(User, test_user_id)
+        test_vehicle = db.session.get(Vehicle, test_vehicle_id)
 
         assert test_vehicle.fillups.count() == 2
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
@@ -389,7 +389,7 @@ def test_logs_bulk_download(
 
 def test_logs_bulk_download__error(app_fixture, test_user_id, temp_vehicle_id):
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
+        test_user = db.session.get(User, test_user_id)
 
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
             resp = test_client_authenticated.get(

--- a/tests/integration/test_error_handlers.py
+++ b/tests/integration/test_error_handlers.py
@@ -1,5 +1,6 @@
-from fuel_logger.models import User, Vehicle
+from fuel_logger.models import User
 from werkzeug.exceptions import InternalServerError
+from fuel_logger import db
 
 
 def test_404__html(test_client):
@@ -27,7 +28,7 @@ def test_500__html(app_fixture, test_user_id, mocker):
     mocker.patch("fuel_logger.vehicles.forms.VehicleForm.validate_on_submit", mocked_fn)
 
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
+        test_user = db.session.get(User, test_user_id)
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
             resp = test_client_authenticated.post(
                 "/add_vehicle",
@@ -54,7 +55,7 @@ def test_500__json(app_fixture, test_user_id, mocker):
     mocker.patch("fuel_logger.vehicles.forms.VehicleForm.validate_on_submit", mocked_fn)
 
     with app_fixture.app_context():
-        test_user = User.query.get(test_user_id)
+        test_user = db.session.get(User, test_user_id)
         with app_fixture.test_client(user=test_user) as test_client_authenticated:
             resp = test_client_authenticated.post(
                 "/add_vehicle",

--- a/tests/unit/models/conftest.py
+++ b/tests/unit/models/conftest.py
@@ -32,7 +32,7 @@ def sample_user_id(app_fixture, sample_user_username, sample_user_email):
 @pytest.fixture(autouse=True, scope="function")
 def sample_vehicle_id_1(app_fixture, sample_user_id):
     with app_fixture.app_context():
-        sample_user = User.query.get(sample_user_id)
+        sample_user = db.session.get(User, sample_user_id)
         vehicle_1 = Vehicle(
             make="testmake1",
             model="testmodel1",
@@ -50,7 +50,7 @@ def sample_vehicle_id_1(app_fixture, sample_user_id):
 @pytest.fixture(autouse=True, scope="function")
 def sample_vehicle_id_2(app_fixture, sample_user_id):
     with app_fixture.app_context():
-        sample_user = User.query.get(sample_user_id)
+        sample_user = db.session.get(User, sample_user_id)
         vehicle_2 = Vehicle(
             make="testmake2",
             model="testmodel2",

--- a/tests/unit/models/test_models_fillups.py
+++ b/tests/unit/models/test_models_fillups.py
@@ -1,18 +1,19 @@
 import pytest
 from fuel_logger.models import Fillup
+from fuel_logger import db
 
 
 def test_fillup_odometer_mi(app_fixture, sample_fillup_id_1):
     with app_fixture.app_context():
-        sample_fillup = Fillup.query.get(sample_fillup_id_1)
+        sample_fillup = db.session.get(Fillup, sample_fillup_id_1)
     assert sample_fillup.odometer_km == 500
     assert sample_fillup.odometer_mi == 310
 
 
 def test_fillup_dist(app_fixture, sample_fillup_id_1, sample_fillup_id_2):
     with app_fixture.app_context():
-        sample_fillup_1 = Fillup.query.get(sample_fillup_id_1)
-        sample_fillup_2 = Fillup.query.get(sample_fillup_id_2)
+        sample_fillup_1 = db.session.get(Fillup, sample_fillup_id_1)
+        sample_fillup_2 = db.session.get(Fillup, sample_fillup_id_2)
 
     assert sample_fillup_1.odometer_km == 500
     assert sample_fillup_1.dist is None
@@ -23,8 +24,8 @@ def test_fillup_dist(app_fixture, sample_fillup_id_1, sample_fillup_id_2):
 
 def test_fillup_dist_mi(app_fixture, sample_fillup_id_1, sample_fillup_id_2):
     with app_fixture.app_context():
-        sample_fillup_1 = Fillup.query.get(sample_fillup_id_1)
-        sample_fillup_2 = Fillup.query.get(sample_fillup_id_2)
+        sample_fillup_1 = db.session.get(Fillup, sample_fillup_id_1)
+        sample_fillup_2 = db.session.get(Fillup, sample_fillup_id_2)
 
     assert sample_fillup_1.dist_mi is None
     assert sample_fillup_2.dist_mi == pytest.approx(310, abs=1)
@@ -32,8 +33,8 @@ def test_fillup_dist_mi(app_fixture, sample_fillup_id_1, sample_fillup_id_2):
 
 def test_fillup_lp100k(app_fixture, sample_fillup_id_1, sample_fillup_id_2):
     with app_fixture.app_context():
-        sample_fillup_1 = Fillup.query.get(sample_fillup_id_1)
-        sample_fillup_2 = Fillup.query.get(sample_fillup_id_2)
+        sample_fillup_1 = db.session.get(Fillup, sample_fillup_id_1)
+        sample_fillup_2 = db.session.get(Fillup, sample_fillup_id_2)
 
     assert sample_fillup_1.lp100k is None
     assert sample_fillup_2.lp100k == pytest.approx(5.0)
@@ -41,8 +42,8 @@ def test_fillup_lp100k(app_fixture, sample_fillup_id_1, sample_fillup_id_2):
 
 def test_fillup_mpg(app_fixture, sample_fillup_id_1, sample_fillup_id_2):
     with app_fixture.app_context():
-        sample_fillup_1 = Fillup.query.get(sample_fillup_id_1)
-        sample_fillup_2 = Fillup.query.get(sample_fillup_id_2)
+        sample_fillup_1 = db.session.get(Fillup, sample_fillup_id_1)
+        sample_fillup_2 = db.session.get(Fillup, sample_fillup_id_2)
 
     assert sample_fillup_1.mpg is None
     assert sample_fillup_2.mpg == pytest.approx(47.04, abs=0.1)
@@ -50,8 +51,8 @@ def test_fillup_mpg(app_fixture, sample_fillup_id_1, sample_fillup_id_2):
 
 def test_fillup_mpg_imp(app_fixture, sample_fillup_id_1, sample_fillup_id_2):
     with app_fixture.app_context():
-        sample_fillup_1 = Fillup.query.get(sample_fillup_id_1)
-        sample_fillup_2 = Fillup.query.get(sample_fillup_id_2)
+        sample_fillup_1 = db.session.get(Fillup, sample_fillup_id_1)
+        sample_fillup_2 = db.session.get(Fillup, sample_fillup_id_2)
 
     assert sample_fillup_1.mpg_imp is None
     assert sample_fillup_2.mpg_imp == pytest.approx(56.5, abs=0.1)
@@ -59,7 +60,7 @@ def test_fillup_mpg_imp(app_fixture, sample_fillup_id_1, sample_fillup_id_2):
 
 def test_fillup_repr(app_fixture, sample_fillup_id_1):
     with app_fixture.app_context():
-        sample_fillup_1 = Fillup.query.get(sample_fillup_id_1)
+        sample_fillup_1 = db.session.get(Fillup, sample_fillup_id_1)
 
         assert (
             repr(sample_fillup_1)

--- a/tests/unit/models/test_models_users.py
+++ b/tests/unit/models/test_models_users.py
@@ -1,13 +1,14 @@
 from fuel_logger.models import User, Vehicle
 from fuel_logger.models.users import load_user
 from datetime import datetime, timedelta
+from fuel_logger import db
 
 
 def test_users_get_favourite_vehicle__set(
     app_fixture, sample_user_id, sample_vehicle_id_1
 ):
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
+        user = db.session.get(User, sample_user_id)
         assert user.vehicles.filter_by(is_favourite=True).count() == 1
         assert user.get_favourite_vehicle().id == sample_vehicle_id_1
 
@@ -16,8 +17,8 @@ def test_users_get_favourite_vehicle__not_set(
     app_fixture, sample_user_id, sample_vehicle_id_1
 ):
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
-        sample_vehicle = Vehicle.query.get(sample_vehicle_id_1)
+        user = db.session.get(User, sample_user_id)
+        sample_vehicle = db.session.get(Vehicle, sample_vehicle_id_1)
         first_vehicle = user.vehicles.first()
         sample_vehicle.is_favourite = False
         assert user.vehicles.filter_by(is_favourite=True).count() == 0
@@ -30,9 +31,9 @@ def test_users_set_favourite_vehicle(
     app_fixture, sample_user_id, sample_vehicle_id_1, sample_vehicle_id_2
 ):
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
-        sample_vehicle_1 = Vehicle.query.get(sample_vehicle_id_1)
-        sample_vehicle_2 = Vehicle.query.get(sample_vehicle_id_2)
+        user = db.session.get(User, sample_user_id)
+        sample_vehicle_1 = db.session.get(Vehicle, sample_vehicle_id_1)
+        sample_vehicle_2 = db.session.get(Vehicle, sample_vehicle_id_2)
 
         assert user.vehicles.filter_by(is_favourite=True).count() == 1
         assert sample_vehicle_1.is_favourite == True
@@ -47,14 +48,14 @@ def test_users_set_favourite_vehicle(
 def test_load_user(app_fixture, sample_user_id):
     with app_fixture.app_context():
         loaded_user = load_user(str(sample_user_id))
-        sample_user = User.query.get(sample_user_id)
+        sample_user = db.session.get(User, sample_user_id)
 
         assert loaded_user.id == sample_user.id
 
 
 def test_to_dict(app_fixture, sample_user_id, sample_user_username, sample_user_email):
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
+        user = db.session.get(User, sample_user_id)
 
         assert user.to_dict() == {
             "id": sample_user_id,
@@ -69,7 +70,7 @@ def test_to_dict(app_fixture, sample_user_id, sample_user_username, sample_user_
 
 def test_user_set_password(app_fixture, sample_user_id):
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
+        user = db.session.get(User, sample_user_id)
 
         assert user.password_hash is None
 
@@ -81,7 +82,7 @@ def test_user_set_password(app_fixture, sample_user_id):
 
 def test_user_check_password(app_fixture, sample_user_id):
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
+        user = db.session.get(User, sample_user_id)
 
         assert user.password_hash is None
 
@@ -96,13 +97,13 @@ def test_user_check_password(app_fixture, sample_user_id):
 
 def test_user_repr(app_fixture, sample_user_id, sample_user_username):
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
+        user = db.session.get(User, sample_user_id)
         assert repr(user) == f"<User {sample_user_username}>"
 
 
 def test_user_get_api_token(app_fixture, sample_user_id):
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
+        user = db.session.get(User, sample_user_id)
 
         assert user.api_token is None
         assert user.api_token_expiration is None
@@ -121,7 +122,7 @@ def test_user_get_api_token(app_fixture, sample_user_id):
 
 def test_user_check_token(app_fixture, sample_user_id):
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
+        user = db.session.get(User, sample_user_id)
 
         assert user.api_token is None
         assert user.api_token_expiration is None
@@ -141,7 +142,7 @@ def test_user_check_token(app_fixture, sample_user_id):
 
 def test_user_revoke_token(app_fixture, sample_user_id):
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
+        user = db.session.get(User, sample_user_id)
         token = user.get_api_token()
 
         # Returns correct user based on current token
@@ -154,7 +155,7 @@ def test_user_revoke_token(app_fixture, sample_user_id):
 
 def test_password_reset_token(app_fixture, sample_user_id):
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
+        user = db.session.get(User, sample_user_id)
 
         token = user.get_reset_password_token()
         assert len(token) > 0
@@ -165,7 +166,7 @@ def test_password_reset_token(app_fixture, sample_user_id):
 
 def test_verify_reset_password_token(app_fixture, sample_user_id):
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
+        user = db.session.get(User, sample_user_id)
         token = user.get_reset_password_token()
 
         # Assert the correct user was found from the token

--- a/tests/unit/models/test_models_vehicles.py
+++ b/tests/unit/models/test_models_vehicles.py
@@ -1,10 +1,11 @@
 from fuel_logger.models import Vehicle
 import pytest
+from fuel_logger import db
 
 
 def test_vehicles_get_stats_df__empty(app_fixture, sample_vehicle_id_1):
     with app_fixture.app_context():
-        sample_vehicle = Vehicle.query.get(sample_vehicle_id_1)
+        sample_vehicle = db.session.get(Vehicle, sample_vehicle_id_1)
         df = sample_vehicle.get_stats_df()
 
         assert sample_vehicle.fillups.count() == 0
@@ -18,7 +19,7 @@ def test_vehicles_get_stats_df__exception(
     mocked_fn = mocker.MagicMock("pandas.read_sql", side_effect=Exception)
     mocker.patch("pandas.read_sql", mocked_fn)
     with app_fixture.app_context():
-        sample_vehicle = Vehicle.query.get(sample_vehicle_id_1)
+        sample_vehicle = db.session.get(Vehicle, sample_vehicle_id_1)
 
         # when exception is raised internally for any reason, ensure empty dataframe is returned
         df = sample_vehicle.get_stats_df()
@@ -30,7 +31,7 @@ def test_vehicles_get_stats_df__populated(
     app_fixture, sample_vehicle_id_1, sample_fillup_ids
 ):
     with app_fixture.app_context():
-        sample_vehicle = Vehicle.query.get(sample_vehicle_id_1)
+        sample_vehicle = db.session.get(Vehicle, sample_vehicle_id_1)
         df = sample_vehicle.get_stats_df()
 
         assert sample_vehicle.fillups.count() == 2
@@ -45,7 +46,7 @@ def test_vehicles_current_odometer__km(
     app_fixture, sample_vehicle_id_1, sample_fillup_ids
 ):
     with app_fixture.app_context():
-        sample_vehicle = Vehicle.query.get(sample_vehicle_id_1)
+        sample_vehicle = db.session.get(Vehicle, sample_vehicle_id_1)
 
         assert sample_vehicle.current_odometer == 1000
 
@@ -54,7 +55,7 @@ def test_vehicles_current_odometer__mi(
     app_fixture, sample_vehicle_id_1, sample_fillup_ids
 ):
     with app_fixture.app_context():
-        sample_vehicle = Vehicle.query.get(sample_vehicle_id_1)
+        sample_vehicle = db.session.get(Vehicle, sample_vehicle_id_1)
         sample_vehicle.odo_unit = "mi"
 
         assert sample_vehicle.current_odometer == pytest.approx(621.5, 0.1)
@@ -62,7 +63,7 @@ def test_vehicles_current_odometer__mi(
 
 def test_vehicles_current_odometer__empty(app_fixture, sample_vehicle_id_1):
     with app_fixture.app_context():
-        sample_vehicle = Vehicle.query.get(sample_vehicle_id_1)
+        sample_vehicle = db.session.get(Vehicle, sample_vehicle_id_1)
 
         assert sample_vehicle.current_odometer == None
 
@@ -71,7 +72,7 @@ def test_vehicles_compute_stats__populated(
     app_fixture, sample_vehicle_id_1, sample_fillup_ids
 ):
     with app_fixture.app_context():
-        sample_vehicle = Vehicle.query.get(sample_vehicle_id_1)
+        sample_vehicle = db.session.get(Vehicle, sample_vehicle_id_1)
         stats = sample_vehicle.compute_stats()
 
     assert isinstance(stats, dict)
@@ -82,7 +83,7 @@ def test_vehicles_compute_stats__populated_with_one(
     app_fixture, sample_vehicle_id_1, sample_fillup_id_1
 ):
     with app_fixture.app_context():
-        sample_vehicle = Vehicle.query.get(sample_vehicle_id_1)
+        sample_vehicle = db.session.get(Vehicle, sample_vehicle_id_1)
         stats = sample_vehicle.compute_stats()
 
     # Can't compute stats with less than 2 fillups
@@ -91,14 +92,14 @@ def test_vehicles_compute_stats__populated_with_one(
 
 def test_vehicles_repr(app_fixture, sample_vehicle_id_1):
     with app_fixture.app_context():
-        sample_vehicle = Vehicle.query.get(sample_vehicle_id_1)
+        sample_vehicle = db.session.get(Vehicle, sample_vehicle_id_1)
 
         assert repr(sample_vehicle) == f"<Vehicle testmake1 testmodel1>"
 
 
 def test_vehicles_to_dict(app_fixture, sample_vehicle_id_1):
     with app_fixture.app_context():
-        sample_vehicle = Vehicle.query.get(sample_vehicle_id_1)
+        sample_vehicle = db.session.get(Vehicle, sample_vehicle_id_1)
 
     assert sample_vehicle.to_dict() == {
         "make": "testmake1",
@@ -110,7 +111,7 @@ def test_vehicles_to_dict(app_fixture, sample_vehicle_id_1):
 
 def test_vehicles_bulk_upload_logs(app_fixture, sample_vehicle_id_1, corolla_df):
     with app_fixture.app_context():
-        sample_vehicle = Vehicle.query.get(sample_vehicle_id_1)
+        sample_vehicle = db.session.get(Vehicle, sample_vehicle_id_1)
 
         assert sample_vehicle.fillups.count() == 0
 

--- a/tests/unit/utils/test_email.py
+++ b/tests/unit/utils/test_email.py
@@ -63,7 +63,7 @@ def test_send_password_reset_email(
     mocker.patch("fuel_logger.utils.email.mail", new=mock_mailer)
 
     with app_fixture.app_context():
-        user = User.query.get(sample_user_id)
+        user = db.session.get(User, sample_user_id)
 
     send_password_reset_email(user)
     time.sleep(0.05)
@@ -74,8 +74,3 @@ def test_send_password_reset_email(
     )
     assert mock_mailer.send.call_args.args[0].sender == app_fixture.config["ADMINS"][0]
     assert mock_mailer.send.call_args.args[0].recipients == [sample_user_email]
-    # assert mock_mailer.send.call_args.args[0].body == "Hello world, this is a test"
-    # assert (
-    #     mock_mailer.send.call_args.args[0].html
-    #     == "<h1>Hello world, this is a test</h1>"
-    # )


### PR DESCRIPTION
- test: Remove pytest warning suppression for legacy sqlalchemy queries
- fix: move away from legacy sqlalchemy query API in all rendered views
- fix: move away from legacy sqlalchemy query API in all API paths
- fix: move away from legacy sqlalchemy query API in all other locations in project
